### PR TITLE
Fix spectral norm bug

### DIFF
--- a/Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/Dist_VAE_model_inference.py
+++ b/Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/Dist_VAE_model_inference.py
@@ -27,7 +27,6 @@ class VAEclassification(nn.Module):
         def __init__(self, in_dim, out_dim):
             super().__init__()
             self.fc = spectral_norm(nn.Linear(in_dim, out_dim), n_power_iterations=5)
-            self.fc = nn.Linear(in_dim, out_dim)
             self.bn = nn.BatchNorm1d(out_dim)
             self.swish = swish
 

--- a/Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/RecResVAE.py
+++ b/Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/RecResVAE.py
@@ -28,7 +28,6 @@ class ContinuousResidualVAE(nn.Module):
             super().__init__()
 
             self.fc = spectral_norm(nn.Linear(in_dim, out_dim), n_power_iterations=5)
-            self.fc = nn.Linear(in_dim, out_dim)
             self.bn = nn.BatchNorm1d(out_dim)
             self.swish = swish
 


### PR DESCRIPTION
## Summary
- ensure Dist_VAE residual blocks keep spectral normalization

## Testing
- `python -m py_compile Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/Dist_VAE_model_inference.py`
- `python -m py_compile Dist_VAE/distillation_VAE_pretraining_model/distillation_VAE_pretraining_model/RecResVAE.py`


------
https://chatgpt.com/codex/tasks/task_e_683fa03a4c848325981568c9d534ea82